### PR TITLE
Add JobState enum and refactor job state tracking

### DIFF
--- a/Sources/AsyncScheduler/Backend/Types/JobState.swift
+++ b/Sources/AsyncScheduler/Backend/Types/JobState.swift
@@ -1,0 +1,13 @@
+//
+//  JobState.swift
+//  swift-async-scheduler
+//
+//  Created by Damian Van de Kauter on 02/12/2025.
+//
+
+import Foundation
+
+internal enum JobState {
+    
+    case running
+}


### PR DESCRIPTION
Introduces a new JobState enum to represent job execution state and refactors AsyncScheduler to track job states per job using a dictionary. This improves handling of concurrent job execution and overrun policies.

Fixes #3 