### PR TITLE
Refactor AsyncScheduler to use Job ID as key

### DIFF
--- a/Sources/AsyncScheduler/Backend/Extensions/AsyncScheduler/AsyncScheduler+Convenience.swift
+++ b/Sources/AsyncScheduler/Backend/Extensions/AsyncScheduler/AsyncScheduler+Convenience.swift
@@ -16,13 +16,13 @@ public extension AsyncScheduler {
         errorPolicy: ErrorPolicy = .ignore,
         overrunPolicy: OverrunPolicy = .skip,
         _ action: @escaping @Sendable () async throws -> Void
-    ) -> Job.ID {
-        var job = Job(name, schedule: .interval(interval), action: action)
+    ) -> Job {
+        var scheduledJob = ScheduledJob(name, schedule: .interval(interval), action: action)
         
-        job.withErrorPolicy(errorPolicy)
-        job.overrunPolicy(overrunPolicy)
+        scheduledJob.withErrorPolicy(errorPolicy)
+        scheduledJob.overrunPolicy(overrunPolicy)
         
-        return schedule(job)
+        return schedule(scheduledJob)
     }
 }
 
@@ -35,13 +35,13 @@ public extension AsyncScheduler {
         errorPolicy: ErrorPolicy = .ignore,
         overrunPolicy: OverrunPolicy = .skip,
         _ action: @escaping @Sendable () async throws -> Void
-    ) -> Job.ID {
-        var job = Job(name, schedule: .daily(hour: hour, minute: minute, timeZone: timeZone), action: action)
+    ) -> Job {
+        var scheduledJob = ScheduledJob(name, schedule: .daily(hour: hour, minute: minute, timeZone: timeZone), action: action)
         
-        job.withErrorPolicy(errorPolicy)
-        job.overrunPolicy(overrunPolicy)
+        scheduledJob.withErrorPolicy(errorPolicy)
+        scheduledJob.overrunPolicy(overrunPolicy)
         
-        return schedule(job)
+        return schedule(scheduledJob)
     }
 }
 
@@ -54,12 +54,12 @@ public extension AsyncScheduler {
         errorPolicy: ErrorPolicy = .ignore,
         overrunPolicy: OverrunPolicy = .skip,
         _ action: @escaping @Sendable () async throws -> Void
-    ) -> Job.ID {
-        var job = Job(name, schedule: .cron(expression), action: action)
+    ) -> Job {
+        var scheduledJob = ScheduledJob(name, schedule: .cron(expression), action: action)
         
-        job.withErrorPolicy(errorPolicy)
-        job.overrunPolicy(overrunPolicy)
+        scheduledJob.withErrorPolicy(errorPolicy)
+        scheduledJob.overrunPolicy(overrunPolicy)
         
-        return schedule(job)
+        return schedule(scheduledJob)
     }
 }

--- a/Sources/AsyncScheduler/Backend/Models/ScheduledJob.swift
+++ b/Sources/AsyncScheduler/Backend/Models/ScheduledJob.swift
@@ -10,6 +10,8 @@ import Foundation
 public struct ScheduledJob {
     
     public let id: UUID
+    public var job: AsyncScheduler.Job { id }
+    
     public let name: String?
     public let schedule: Schedule
     public let action: @Sendable () async throws -> Void


### PR DESCRIPTION
Changed AsyncScheduler to use ScheduledJob.ID (UUID) as the Job type and as the key for internal dictionaries, improving clarity and consistency. Updated convenience methods and ScheduledJob to support this change, and adjusted method signatures and usages accordingly.