### PR TITLE
Add idle waiting and run method to AsyncScheduler

### DIFF
--- a/Sources/AsyncScheduler/AsyncScheduler.swift
+++ b/Sources/AsyncScheduler/AsyncScheduler.swift
@@ -15,12 +15,12 @@ public actor AsyncScheduler {
     private var jobStates: [Job : JobState]
     
     private var idleContinuation: CheckedContinuation<Void, Never>? = nil
-
+    
     public init() {
         self.tasks = [:]
         self.jobStates = [:]
     }
-
+    
     @discardableResult
     public func schedule(_ scheduledJob: ScheduledJob) -> Job {
         let runner: @Sendable () async -> Void = { [unowned self] in
@@ -37,16 +37,30 @@ public actor AsyncScheduler {
         return job
     }
     
-    public func cancel(_ job: Job) {
+    public func cancel(_ job: Job) async {
+        // mark cancelled first so the running loop can observe it
+        jobStates[job] = .cancelled
         if let task = tasks.removeValue(forKey: job) {
             task.cancel()
+            // wait for the task to finish
+            _ = await task.value
         }
         resumeIfIdle()
     }
     
-    public func cancelAll() {
-        for task in tasks.values {
+    public func cancelAll() async {
+        // capture current tasks
+        let currentTasks = tasks
+        // mark all jobs cancelled first
+        for job in currentTasks.keys {
+            jobStates[job] = .cancelled
+        }
+        for task in currentTasks.values {
             task.cancel()
+        }
+        // await their completion
+        for task in currentTasks.values {
+            _ = await task.value
         }
         tasks.removeAll()
         resumeIfIdle()
@@ -71,82 +85,93 @@ public extension AsyncScheduler {
     ///
     static func run(_ configure: ((AsyncScheduler) async -> Void)? = nil) async {
         let scheduler = AsyncScheduler()
-
+        
         await configure?(scheduler)
-
+        
         // Suspend until scheduler becomes idle (no active tasks)
         await scheduler.waitUntilIdle()
     }
 }
 
 private extension AsyncScheduler {
+    
     func execute(_ scheduledJob: ScheduledJob) async {
         let job = scheduledJob.job
-
-        let task: Task = Task { [weak self] in
-            guard let self = self else { return }
-
-            while !Task.isCancelled {
-                try? await self.sleep(for: scheduledJob.schedule.sleep)
-
-                guard !Task.isCancelled else { break }
-
-                if await self.isJobRunning(job) {
-                    switch scheduledJob.overrunPolicy {
-                    case .skip:
-                        continue
-                    case .wait:
-                        while await self.isJobRunning(job) && !Task.isCancelled {
-                            try? await self.sleep(for: .milliseconds(10))
-                        }
-                    case .overlap:
-                        break //TODO: Allow overlapping executions
+        
+        // Run the job loop inline in the Task that called `execute(_:)`.
+        // This ensures the Task stored in `tasks` is the actual running task
+        // and that cancelling it via `cancel(_:)` will stop the loop immediately.
+        while !Task.isCancelled {
+            // If the job was cancelled via actor state, stop.
+            if jobStates[job] == .cancelled { break }
+            
+            try? await self.sleep(for: scheduledJob.schedule.sleep)
+            
+            guard !Task.isCancelled else { break }
+            
+            if jobStates[job] == .cancelled { break }
+            
+            if await self.isJobRunning(job) {
+                switch scheduledJob.overrunPolicy {
+                case .skip:
+                    continue
+                case .wait:
+                    while await self.isJobRunning(job) && !Task.isCancelled {
+                        try? await self.sleep(for: .milliseconds(10))
                     }
+                case .overlap:
+                    break //TODO: Allow overlapping executions
                 }
-
-                await self.markJobRunning(job)
-
-                // Execute the job action inline, not in a detached child Task
-                try? await scheduledJob.action()
-
-                guard !Task.isCancelled else { break }
-
-                await self.markJobFinished(job)
             }
-
-            // Final cleanup in case of cancellation
+            
+            if jobStates[job] == .cancelled { break }
+            
+            await self.markJobRunning(job)
+            
+            // Execute the job action inline, not in a detached child Task
+            try? await scheduledJob.action(job)
+            
+            guard !Task.isCancelled else { break }
+            
+            if jobStates[job] == .cancelled { break }
+            
             await self.markJobFinished(job)
         }
-
-        await storeTask(job, task)
+        
+        // Final cleanup in case of cancellation
+        await self.removeTaskAndFinish(job)
     }
-
-    private func storeTask(_ job: Job, _ task: Task<Void, Never>) async {
-        tasks[job] = task
-    }
-
+    
     private func isJobRunning(_ job: Job) async -> Bool {
         jobStates[job] == .running
     }
-
+    
     private func markJobRunning(_ job: Job) async {
         jobStates[job] = .running
     }
-
+    
     private func markJobFinished(_ job: Job) async {
+        // only clear running state; do not remove the stored Task here because
+        // the Task may still be looping and scheduling further runs. Removing
+        // the Task while it's still running causes cancel/cancelAll to miss it.
+        jobStates.removeValue(forKey: job)
+    }
+    
+    private func removeTaskAndFinish(_ job: Job) async {
         tasks.removeValue(forKey: job)
         jobStates.removeValue(forKey: job)
         resumeIfIdle()
     }
-
+    
     private func runJobAction(_ scheduledJob: ScheduledJob) async {
         let job = scheduledJob.job
         defer { Task { await markJobFinished(job) } }
-        try? await scheduledJob.action()
+        try? await scheduledJob.action(job)
     }
-
+    
     func resumeIfIdle() {
         if tasks.isEmpty {
+            print("AsyncScheduler: Scheduler is now idle; resuming waiters.")
             idleContinuation?.resume()
             idleContinuation = nil
         }

--- a/Sources/AsyncScheduler/Backend/Extensions/AsyncScheduler/AsyncScheduler+Convenience.swift
+++ b/Sources/AsyncScheduler/Backend/Extensions/AsyncScheduler/AsyncScheduler+Convenience.swift
@@ -9,6 +9,8 @@ import Foundation
 
 public extension AsyncScheduler {
     
+    /// - Important: Do not reference job from inside the closure as the job isn't initialized yet.
+    /// Instead use the other overload that provides the job as closure parameter.
     @discardableResult
     func every(
         _ interval: Duration,
@@ -24,10 +26,27 @@ public extension AsyncScheduler {
         
         return schedule(scheduledJob)
     }
+    
+    func every(
+        _ interval: Duration,
+        name: String? = nil,
+        errorPolicy: ErrorPolicy = .ignore,
+        overrunPolicy: OverrunPolicy = .skip,
+        _ action: @escaping @Sendable (Job) async throws -> Void
+    ) {
+        var scheduledJob = ScheduledJob(name, schedule: .interval(interval), action: action)
+        
+        scheduledJob.withErrorPolicy(errorPolicy)
+        scheduledJob.overrunPolicy(overrunPolicy)
+        
+        schedule(scheduledJob)
+    }
 }
 
 public extension AsyncScheduler {
     
+    /// - Important: Do not reference job from inside the closure as the job isn't initialized yet.
+    /// Instead use the other overload that provides the job as closure parameter.
     @discardableResult
     func daily(
         on hour: Int, _ minute: Int, timeZone: TimeZone = .current,
@@ -43,10 +62,27 @@ public extension AsyncScheduler {
         
         return schedule(scheduledJob)
     }
+    
+    func daily(
+        on hour: Int, _ minute: Int, timeZone: TimeZone = .current,
+        name: String? = nil,
+        errorPolicy: ErrorPolicy = .ignore,
+        overrunPolicy: OverrunPolicy = .skip,
+        _ action: @escaping @Sendable (Job) async throws -> Void
+    ) {
+        var scheduledJob = ScheduledJob(name, schedule: .daily(hour: hour, minute: minute, timeZone: timeZone), action: action)
+        
+        scheduledJob.withErrorPolicy(errorPolicy)
+        scheduledJob.overrunPolicy(overrunPolicy)
+        
+        schedule(scheduledJob)
+    }
 }
 
 public extension AsyncScheduler {
     
+    /// - Important: Do not reference job from inside the closure as the job isn't initialized yet.
+    /// Instead use the other overload that provides the job as closure parameter.
     @discardableResult
     func cron(
         _ expression: String,
@@ -61,5 +97,20 @@ public extension AsyncScheduler {
         scheduledJob.overrunPolicy(overrunPolicy)
         
         return schedule(scheduledJob)
+    }
+    
+    func cron(
+        _ expression: String,
+        name: String? = nil,
+        errorPolicy: ErrorPolicy = .ignore,
+        overrunPolicy: OverrunPolicy = .skip,
+        _ action: @escaping @Sendable (Job) async throws -> Void
+    ) {
+        var scheduledJob = ScheduledJob(name, schedule: .cron(expression), action: action)
+        
+        scheduledJob.withErrorPolicy(errorPolicy)
+        scheduledJob.overrunPolicy(overrunPolicy)
+        
+        schedule(scheduledJob)
     }
 }

--- a/Sources/AsyncScheduler/Backend/Models/ScheduledJob.swift
+++ b/Sources/AsyncScheduler/Backend/Models/ScheduledJob.swift
@@ -14,11 +14,11 @@ public struct ScheduledJob {
     
     public let name: String?
     public let schedule: Schedule
-    public let action: @Sendable () async throws -> Void
+    public let action: @Sendable (AsyncScheduler.Job) async throws -> Void
     
     public var errorPolicy: ErrorPolicy
     public var overrunPolicy: OverrunPolicy
-
+    
     public init(
         _ name: String? = nil,
         schedule: Schedule,
@@ -27,8 +27,20 @@ public struct ScheduledJob {
         self.id = UUID()
         self.name = name
         self.schedule = schedule
+        self.action = { _ in try await action() }
+        self.errorPolicy = .ignore
+        self.overrunPolicy = .skip
+    }
+    
+    public init(
+        _ name: String? = nil,
+        schedule: Schedule,
+        action: @escaping @Sendable (AsyncScheduler.Job) async throws -> Void
+    ) {
+        self.id = UUID()
+        self.name = name
+        self.schedule = schedule
         self.action = action
-        
         self.errorPolicy = .ignore
         self.overrunPolicy = .skip
     }
@@ -48,3 +60,4 @@ public extension ScheduledJob {
         self.overrunPolicy = overrunPolicy
     }
 }
+

--- a/Sources/AsyncScheduler/Backend/Types/JobState.swift
+++ b/Sources/AsyncScheduler/Backend/Types/JobState.swift
@@ -1,13 +1,7 @@
-//
-//  JobState.swift
-//  swift-async-scheduler
-//
-//  Created by Damian Van de Kauter on 02/12/2025.
-//
-
-import Foundation
+// ...existing code...
 
 internal enum JobState {
     
     case running
+    case cancelled
 }

--- a/Tests/AsyncSchedulerTests/AsyncSchedulerTests.swift
+++ b/Tests/AsyncSchedulerTests/AsyncSchedulerTests.swift
@@ -14,14 +14,14 @@ actor Box<T> {
 func testIntervalJobRuns() async throws {
     let scheduler = AsyncScheduler()
     let counter = Box(0)
-
+    
     let job = await scheduler.every(.seconds(0.05)) {
         await counter.update { $0 += 1 }
     }
-
+    
     try? await Task.sleep(nanoseconds: 150_000_000) // ~0.15s
     await scheduler.cancel(job)
-
+    
     let count = await counter.get()
     #expect(count > 1, "Counter value: \(count)")
 }
@@ -30,44 +30,45 @@ func testIntervalJobRuns() async throws {
 func testIntervalJobCancels() async throws {
     let scheduler = AsyncScheduler()
     let counter = Box(0)
-
-    let job = await scheduler.every(.seconds(0.05)) {
+    
+    let job = await scheduler.every(.nanoseconds(50_000_000)) {
         await counter.update { $0 += 1 }
     }
-
-    try? await Task.sleep(nanoseconds: 80_000_000)
-    await scheduler.cancel(job)
-
-    let afterCancel = await counter.get()
+    
     try? await Task.sleep(nanoseconds: 120_000_000)
-
-    #expect(await counter.get() == afterCancel)
+    await scheduler.cancel(job)
+    
+    let afterCancel = await counter.get()
+    try? await Task.sleep(nanoseconds: 200_000_000)
+    
+    let finalCount = await counter.get()
+    #expect(finalCount == afterCancel)
 }
 
 @Test
 func testDailySchedulesTomorrowIfPassed() async throws {
     let scheduler = AsyncScheduler()
-
+    
     // Daily schedule at 00:00 local time
     // We force next run to be > 0 seconds (tomorrow)
     let now = Date()
     let calendar = Calendar(identifier: .gregorian)
     let comps = calendar.dateComponents([.hour, .minute], from: now)
-
+    
     let hour = max(0, comps.hour! - 1) // ensure the scheduled time for today is already passed
     let minute = comps.minute!
-
+    
     let job = await scheduler.daily(on: hour, minute, timeZone: .current) { }
-
+    
     // Extract the sleep duration using the internal API if available,
     // but here we validate indirectly by checking that job's loop starts and waits.
     // We allow the scheduler loop to initialize:
     try? await Task.sleep(nanoseconds: 50_000_000)
-
+    
     // If it didn't crash, and didn't immediately run the action,
     // we consider this correct (since we cannot check exact date math here).
     await scheduler.cancel(job)
-
+    
     #expect(true)
 }
 
@@ -76,19 +77,19 @@ func testCancelAll() async throws {
     let scheduler = AsyncScheduler()
     let a = Box(0)
     let b = Box(0)
-
+    
     await scheduler.every(.seconds(0.05)) { await a.update { $0 += 1 } }
     await scheduler.every(.seconds(0.05)) { await b.update { $0 += 1 } }
-
+    
     try? await Task.sleep(nanoseconds: 120_000_000)
-
+    
     await scheduler.cancelAll()
-
+    
     let aAfter = await a.get()
     let bAfter = await b.get()
-
+    
     try? await Task.sleep(nanoseconds: 120_000_000)
-
+    
     #expect(await a.get() == aAfter)
     #expect(await b.get() == bAfter)
 }
@@ -96,13 +97,41 @@ func testCancelAll() async throws {
 @Test
 func testRunWaitsUntilIdle() async throws {
     let completed = Box(false)
-
-    await AsyncScheduler.run { scheduler in
-        let job = await scheduler.every(.seconds(0.05)) {
-            await completed.set(true)
-            await scheduler.cancel(job)
+    
+    enum TimeoutError: Error { case timedOut }
+    let timeoutNs: UInt64 = 2_000_000_000 // 1s timeout to avoid hanging forever
+    
+    await withThrowingTaskGroup(of: Void.self) { group in
+        // Task A: run the scheduler normally
+        group.addTask {
+            await AsyncScheduler.run { scheduler in
+                // Schedule a job that marks completion when it runs once.
+                await scheduler.every(.seconds(0.05)) { job in
+                    print("Job executed")
+                    await completed.set(true)
+                    
+                    Task {
+                        try? await Task.sleep(nanoseconds: 10_000_000) // small yield
+                        await scheduler.cancel(job)
+                    }
+                }
+            }
+        }
+        
+        // Task B: timeout
+        group.addTask {
+            try await Task.sleep(nanoseconds: timeoutNs)
+            throw TimeoutError.timedOut
+        }
+        
+        do {
+            _ = try await group.next()
+            
+            group.cancelAll()
+        } catch {
+            #expect(Bool(false), "AsyncScheduler.run did not finish within timeout: \(error)")
         }
     }
-
+    
     #expect(await completed.get())
 }


### PR DESCRIPTION
Introduces waitUntilIdle and idle continuation logic to AsyncScheduler, allowing external code to await until all jobs are finished. Adds a static run method for running a scheduler until idle. Updates internal job execution and cleanup logic. Expands test coverage for interval jobs, cancellation, daily scheduling, cancelAll, and run/idle behavior.